### PR TITLE
Increase floating-point precision of EMRISur1dq1e4.

### DIFF
--- a/gwsurrogate/catalog.py
+++ b/gwsurrogate/catalog.py
@@ -147,7 +147,9 @@ _surrogate_world['EMRISur1dq1e4'] = \
   point-particle perturbation theory waveforms set alpha_emri = 1.
   Available modes are [(2,2), (2,1), (3,3), (3,2), (3,1), (4,4), (4,3), 
   (4,2), (5,5), (5,4), (5,3)]. The m<0 modes are deduced from the m>0 modes.
-  Model details can be found in Rifat et al. 2019, arXiv:1910.10473.''',
+  Model details can be found in Rifat et al. 2019, arXiv:1910.10473. NOTE: 
+  the datasets in this hdf5 file are 32-bit (single) precision. Some are up-cast
+  to double in SurrogateIO.''',
   '''https://arxiv.org/abs/1910.10473''',
   'd145958484738e0c7292e084a66a96fa')
 

--- a/gwsurrogate/surrogate.py
+++ b/gwsurrogate/surrogate.py
@@ -1703,7 +1703,7 @@ class SurrogateEvaluator(object):
                 Skip sanity checks for inputs. Use this if you want to
                 extrapolate outside allowed range. Default: False.
 
-    taper_end_durataion:
+    taper_end_duration:
                 Taper the last TAPER_END_DURATION (M) of a time-domain waveform
                 in units of M. For exmple, passing 40 will taper the last 40M.
                 When set to None, no taper is applied

--- a/gwsurrogate/surrogateIO.py
+++ b/gwsurrogate/surrogateIO.py
@@ -418,7 +418,7 @@ class H5Surrogate(SurrogateBaseIO):
       self.B = self.file[subdir+self._B_h5][:]	
     else:
       raise ValueError('invalid surrogate type')
-    
+
     ### Information about phase/amp parametric fit ###
     if self._affine_map_h5 in self.keys:
       self.affine_map = self.chars_to_string(self.file[subdir+self._affine_map_h5][()])
@@ -558,6 +558,31 @@ class H5Surrogate(SurrogateBaseIO):
     
     if closeQ:
       self.file.close()
+
+
+
+    ### check that data has been loaded as 64-bit double (NOTE: not all datasets are checked here)
+    ### Why is this important? It was found that using np.float32 can lead to problems,
+    ### for example when trying to comput flow, which is sensitive to small changes, round-off
+    ### errors can give wildly incorrect values (off by ~10%)
+    if not isinstance(self.times[0], np.float64):
+      print("Time grid loaded with data type %s. Changing to float64..."%type(self.times[0]))
+      self.times = np.array(self.times, dtype=np.float64)
+      self.tmin = self.times[0]
+      self.tmax = self.times[-1]
+    if self.surrogate_mode_type == 'amp_phase_basis':
+      if not isinstance(self.B_1[0][0], np.float64):
+        print("Basis matrix loaded with data type %s. Changing to float64..."%type(self.B_1[0][0]))
+        self.B_1 = np.array(self.B_1, dtype=np.float64)
+        self.B_2 = np.array(self.B_2, dtype=np.float64)
+    elif self.surrogate_mode_type  == 'waveform_basis':
+      if not isinstance(np.real(self.B[0][0]), np.float64):
+        print("Basis matrix loaded with data type %s. Should change to float64...BUT NOT CODED YET!!!"%type(self.B_1[0][0]))
+    if self.fit_type_amp == "spline_1d" and self.fit_type_phase == "spline_1d":
+      if not isinstance(self.fitparams_amp[0][0][0], np.float64):
+        print("Fit parameters loaded with data type %s. This is probably OK. NOT changing to float64..."%type(self.fitparams_amp[0][0][0]))
+    #    self.fitparams_amp = np.array(self.fitparams_amp, dtype=np.float64)
+    #    self.fitparams_phase = np.array(self.fitparams_phase, dtype=np.float64)
     
     pass
     


### PR DESCRIPTION
All hdf5 datasets of EMRISur1dq1e4 are stored in single, which is problematic
for certain computations, e.g. computing flow from the 22 mode. Upcasting
to double seems to fix the issues that have been noticed so far.