### PR TITLE
advertise gwsurrogate models to pycbc

### DIFF
--- a/gwsurrogate/pycbc.py
+++ b/gwsurrogate/pycbc.py
@@ -1,0 +1,79 @@
+""" Utilties to interface gwsurrogate models with the generic PyCBC
+gw waveform interfaces
+"""
+import gwsurrogate as gws
+
+_cached_models = {}
+
+def gws_td_gen(**params):
+    """ Generate pycbc format time domain GW polarizations
+
+    Parameters
+    ----------
+    params: dict
+        A dictionary containing the waveform parameters
+
+    Returns
+    -------
+    hp: pycbc.types.TimeSeries
+        The time series containg the plus polarization in the
+        radiation frame.
+    hc: pycbc.types.TimeSeries
+        The time series containg the cross polarization in the
+        radiation frame.
+    """
+    import gwsurrogate as gws
+    from pycbc.types import TimeSeries
+    from pycbc import conversions as conv
+
+    # Parameter names should follow the convention of
+    # https://github.com/gwastro/pycbc/blob/master/pycbc/waveform/parameters.py#L162
+    # but are not limited to these names for additional effects
+    apx = params['approximant'].replace('GWS-', '')
+
+    if apx not in _cached_models:
+        _cached_models[apx] = gws.LoadSurrogate(apx)
+    model = _cached_models[apx]
+
+    # convert from pycbc parameter name conventions to gwsurrogate
+    q1 = params['mass1'] / params['mass2']
+    q2 = params['mass2'] / params['mass1']
+
+
+    q = [q1, q2]
+    chi = [[params['spin1x'], params['spin1y'], params['spin1z']],
+           [params['spin2x'], params['spin2y'], params['spin2z']]]
+
+    # sort so first mass is larger
+    if q1 >= 1:
+        a, b = 0, 1
+    else:
+        a, b = 1, 0
+
+    tides = None
+    if model.keywords['Tidal']:
+        lam = [params['lambda1'], params['lambda2']]
+        tides = {'Lambda1':lam[a], 'Lambda2':lam[b]}
+        tides = {k:tides[k] if tides[k] is not None else 0.0 for k in tides}
+
+    M = params['mass1'] + params['mass2']
+    if params['f_ref'] == 0:
+        params['f_ref'] = params['f_lower']
+
+    _, h, _ = model(q[a], chi[a], chi[b],
+                    M=M,
+                    dist_mpc=params['distance'],
+                    dt=params['delta_t'],
+                    phi_ref=params['coa_phase'],
+                    f_ref=params['f_ref'],
+                    f_low=params['f_lower'],
+                    tidal_opts=tides,
+                    inclination=params['inclination'],
+                    units='mks')
+
+    # Define time=0 as the waveform peak to be consistent with
+    # convention
+    peak_time = abs(h).argmax() * params['delta_t']
+    hp = TimeSeries(h.real, delta_t=params['delta_t'], epoch=-peak_time)
+    hc = TimeSeries(h.imag, delta_t=params['delta_t'], epoch=-peak_time)
+    return hp, hc

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,13 @@ def read_main_file(key):
             if key in line:
                 return line.split('"')[1]
 
+entries = {"pycbc.waveform.td":
+            ["GWS-NRHybSur3dq8 = gwsurrogate.pycbc:gws_td_gen",
+             "GWS-NRSur7dq4 = gwsurrogate.pycbc:gws_td_gen",
+             "GWS-NRHybSur3dq8Tidal = gwsurrogate.pycbc:gws_td_gen",
+            ]
+          }
+
 setup(name='gwsurrogate',
       version=read_main_file("__version__"),
       author=read_main_file("__author__"),
@@ -97,6 +104,7 @@ setup(name='gwsurrogate',
                 'Topic :: Scientific/Engineering :: Mathematics',
                 'Topic :: Scientific/Engineering :: Physics',
       ],
+      entry_points = entries,
       cmdclass = {'build_ext': LateNumpyIncludeCommand},
       ext_modules = extmods,
 )


### PR DESCRIPTION
This PR support into GWsurrogate to advertise its models for use by PyCBC. This follows up on #22. 

This adds only the three time domain models that were exposed through the LoadSurrogate class. It appears there are other models listed in the catalog but I wasn't sure yet how to access these and if the intention was for LoadSurrogate to be able to use those eventually? 

The way this works is that with this patch one can do something like the following. 

```
pip install pycbc gwsurrogate
```

and then use the advertised gwsurrogate models directly within the pycbc library e.g.
```
from matplotlib import pyplot
from pycbc.waveform import get_td_waveform, td_approximants

pyplot.figure(dpi=200)
dist = 1
for apx in ['GWS-NRSur7dq4',
            'GWS-NRHybSur3dq8',
            'GWS-NRHybSur3dq8Tidal',
            'EOBNRv2']:

    hp, hc = get_td_waveform(
                    approximant=apx,
                    mass1=25,
                    mass2=100,
                    delta_t=1.0/4096,
                    f_lower=10.0,
                    distance=dist)
    dist *= 1.50
    hp.plot(label=apx)
pyplot.legend()
pyplot.xlim(float(hp.start_time), 0.2)
pyplot.show()  
```
![download - 2022-05-10T165804 053](https://user-images.githubusercontent.com/2206534/167659232-dc8ac907-a6c4-4f8d-b8c6-f4e966f1a7d2.png)

Only the time-domain PyCBC waveform interface is currently supported, but in the future we could add support for others (i.e. frequency domain, non-equal sample rates, eventually hm / projected forms). 

With the td interface this immediately enables a few things
 * access to basic pycbc waveform uniform interface 
 * use within pycbc bank generation / fitting factor scripts
 * enables immediate use for injection studies with searches / parameter estimation
 * use as a time-domain template for PE 
