### PR TITLE
array_equal to allclose for sanity check on times

### DIFF
--- a/gwsurrogate/surrogate.py
+++ b/gwsurrogate/surrogate.py
@@ -2102,11 +2102,14 @@ class SurrogateEvaluator(object):
         # Assuming times/freqs were specified, so they must be the same
         # when returning
         if (times is not None):
-            if not np.allclose(domain, times):
+            # rtol=1e-05, atol=1e-08 were numpy v1.24 defaults. We have hardcoded
+            # them here to make the values transparent and guard against
+            # future changes to the defaults by numpy developers
+            if not np.allclose(domain, times, rtol=1e-05, atol=1e-08):
                 raise Exception("times were given as input but returned "
                     "domain somehow does not match.")
         if (freqs is not None):
-            if not np.allclose(domain, freqs):
+            if not np.allclose(domain, freqs, rtol=1e-05, atol=1e-08):
                 raise Exception("freqs were given as input but returned "
                     "domain somehow does not match.")
 

--- a/gwsurrogate/surrogate.py
+++ b/gwsurrogate/surrogate.py
@@ -2102,11 +2102,11 @@ class SurrogateEvaluator(object):
         # Assuming times/freqs were specified, so they must be the same
         # when returning
         if (times is not None):
-            if not np.array_equal(domain, times):
+            if not np.allclose(domain, times):
                 raise Exception("times were given as input but returned "
                     "domain somehow does not match.")
         if (freqs is not None):
-            if not np.array_equal(domain, freqs):
+            if not np.allclose(domain, freqs):
                 raise Exception("freqs were given as input but returned "
                     "domain somehow does not match.")
 


### PR DESCRIPTION
array_equal was too stringent, it was catching 1e-12 level differences, which can sometimes happen when switching back and forth between dimeless and mks times.