### PR TITLE
Go back to using ubuntu-latest for actions (18.04 is gone)

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -12,8 +12,7 @@ on:
 jobs:
   build:
 
-#    runs-on: ubuntu-latest
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
 
@@ -30,7 +29,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest nose
+        pip install flake8 pytest nose wheel
         sudo apt-get -yq install gcc
         sudo apt-get -yq install libgsl-dev
 #    - name: Lint with flake8
@@ -42,7 +41,7 @@ jobs:
     - name: Test with pytest
       run: |
         cd ..
-        pip install -e gwsurrogate
+        pip install --no-build-isolation -e gwsurrogate
         cd gwsurrogate
         pwd
         pip list


### PR DESCRIPTION
To make github actions work, I needed to change from the pinned version ubuntu-18.04 to ubuntu-latest. For some reason that I don't understand, I also had to add the `--no-build-isolation` flag so that `numpy` (which was indeed installed as a dep) would be available within the build env. I also had to install `wheel`. This makes me wonder if installing from PyPI works without all these extra flags and deps? But that should be addressed in a separate PR.