### PR TITLE
Simplify build configuration in setup.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
     requires = [
         "setuptools>=61.0",
-        "numpy"
+        "oldest-supported-numpy"
     ]
     build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,8 @@ import os
 
 from setuptools import setup, Extension
 
+import numpy
+
 # all extensions here
 extmods = []
 
@@ -30,29 +32,11 @@ extmods.append(extmod)
 extmod = Extension(
     "gwsurrogate.precessing_utils._utils",
     sources=["gwsurrogate/precessing_utils/src/precessing_utils.c"],
-    include_dirs=["gwsurrogate/precessing_utils/include"],
+    include_dirs=["gwsurrogate/precessing_utils/include", numpy.get_include()],
     language="c",
     extra_compile_args=["-std=c99", "-fPIC", "-O3"],
 )
 extmods.append(extmod)
-
-# Workaround: Only import numpy once reqs have been imported
-# Thanks to https://stackoverflow.com/a/42163080/1695428
-from distutils.command.build_ext import build_ext
-
-
-class LateNumpyIncludeCommand(build_ext):
-    """build_ext command for use when numpy headers are needed."""
-
-    def run(self):
-        # Import numpy here, only when headers are needed
-        import numpy
-
-        # Add numpy headers to include_dirs
-        self.include_dirs.append(numpy.get_include())
-
-        # Call original build_ext command
-        build_ext.run(self)
 
 
 # Extract code version from surrogate.py
@@ -114,6 +98,5 @@ setup(
         "Topic :: Scientific/Engineering :: Physics",
     ],
     entry_points=entries,
-    cmdclass={"build_ext": LateNumpyIncludeCommand},
     ext_modules=extmods,
 )

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,6 @@
 import os
 
-try:
-    from setuptools import setup, Extension
-
-    setup
-except ImportError:  # currently not supported
-    raise ImportError("GWSurrogate requires setuptools")
-    # from distutils.core import setup # currently not supported
-    # setup
+from setuptools import setup, Extension
 
 # To render markdown. See https://github.com/pypa/pypi-legacy/issues/148
 try:

--- a/setup.py
+++ b/setup.py
@@ -2,14 +2,6 @@ import os
 
 from setuptools import setup, Extension
 
-# To render markdown. See https://github.com/pypa/pypi-legacy/issues/148
-try:
-    import pypandoc
-
-    long_description = pypandoc.convert_file("README.md", "rst")
-except ImportError as e:
-    long_description = open("README.md").read()
-
 # all extensions here
 extmods = []
 
@@ -100,7 +92,7 @@ setup(
     ],
     description="An easy to use interface to gravitational wave surrogate models",
     long_description_content_type="text/markdown",
-    long_description=long_description,
+    long_description=open("README.md").read(),
     # will start new downloads if these are installed in a non-standard location
     install_requires=[
         "numpy",


### PR DESCRIPTION
This PR adds a `pyproject.toml` file to simplify building this project with modern versions of `pip`.

Specifying the project _build_ requirements outside of `setup.py` allows `pip` to collect and pre-install them, guaranteeing their availability to the build. This means a number of the workarounds/protections can be removed from `setup.py`.

This also removes the use of `distutils` which was removed from the standard library in Python 3.12.