### PR TITLE
Bug fix/remove nose

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.11
+        python-version: 3
 
     - name: Install dependencies
       run: |

--- a/gwsurrogate/new/spline_evaluation.py
+++ b/gwsurrogate/new/spline_evaluation.py
@@ -241,6 +241,7 @@ class TensorSplineGrid(SimpleH5Object):
 
         # Create 4^d hypercube of bspline products
         # Reduce uses left to right, transposes sound ugly, just reverse.
+        # TODO: It could be faster to use np.ravel(np.outer(...))
         eval_prods = reduce(
             lambda a, b: np.array([a * x for x in b]), spline_evals[::-1]
         )

--- a/gwsurrogate/surrogateIO.py
+++ b/gwsurrogate/surrogateIO.py
@@ -556,9 +556,9 @@ class H5Surrogate(SurrogateBaseIO):
             fitparams_amp.append([spline_knots_amp[i], self.fitparams_amp[i], degree])
           for i in range(num_fits_phase):
             fitparams_phase.append([spline_knots_phase[i], self.fitparams_phase[i], degree])
-          # due to different sizes of amp/phase fits, we cannot convert this 
-          # to a numpy array of numerical datatypes. Instead, it needs to be 
-          # saved as an object type, which appears to be an array of pointers
+          # these are ragged structures, so we need to explicitly request dtype=object
+          # as it cannot be converted to an arrary with numerical datatypes
+          # Instead, it needs to be  saved as an object type, which appears to be an array of pointers
           # to arrays. This could have some efficiency impact.
           # https://stackoverflow.com/questions/29877508/what-does-dtype-object-mean-while-creating-a-numpy-array
           self.fitparams_amp = np.array(fitparams_amp,dtype=object)
@@ -587,9 +587,9 @@ class H5Surrogate(SurrogateBaseIO):
             fitparams_re.append([spline_knots_re[i], self.fitparams_re[i], degree])
           for i in range(num_fits_im):
             fitparams_im.append([spline_knots_im[i], self.fitparams_im[i], degree])
-          # due to different sizes of amp/phase fits, we cannot convert this 
-          # to a numpy array of numerical datatypes. Instead, it needs to be 
-          # saved as an object type, which appears to be an array of pointers
+          # these are ragged structures, so we need to explicitly request dtype=object
+          # as it cannot be converted to an arrary with numerical datatypes
+          # Instead, it needs to be  saved as an object type, which appears to be an array of pointers
           # to arrays. This could have some efficiency impact.
           # https://stackoverflow.com/questions/29877508/what-does-dtype-object-mean-while-creating-a-numpy-array
           self.fitparams_re = np.array(fitparams_re,dtype=object)
@@ -613,9 +613,9 @@ class H5Surrogate(SurrogateBaseIO):
         for i in range(num_fits):
           fitparams_amp.append([spline_knots, self.fitparams_amp[i,:], degree])
           fitparams_phase.append([spline_knots, self.fitparams_phase[i,:], degree])
-        # due to different sizes of amp/phase fits, we cannot convert this 
-        # to a numpy array of numerical datatypes. Instead, it needs to be 
-        # saved as an object type, which appears to be an array of pointers
+        # these are ragged structures, so we need to explicitly request dtype=object
+        # as it cannot be converted to an arrary with numerical datatypes
+        # Instead, it needs to be  saved as an object type, which appears to be an array of pointers
         # to arrays. This could have some efficiency impact.
         # https://stackoverflow.com/questions/29877508/what-does-dtype-object-mean-while-creating-a-numpy-array
         self.fitparams_amp = np.array(fitparams_amp,dtype=object)

--- a/gwsurrogate/surrogateIO.py
+++ b/gwsurrogate/surrogateIO.py
@@ -613,8 +613,13 @@ class H5Surrogate(SurrogateBaseIO):
         for i in range(num_fits):
           fitparams_amp.append([spline_knots, self.fitparams_amp[i,:], degree])
           fitparams_phase.append([spline_knots, self.fitparams_phase[i,:], degree])
-        self.fitparams_amp = np.array(fitparams_amp)
-        self.fitparams_phase = np.array(fitparams_phase)
+        # due to different sizes of amp/phase fits, we cannot convert this 
+        # to a numpy array of numerical datatypes. Instead, it needs to be 
+        # saved as an object type, which appears to be an array of pointers
+        # to arrays. This could have some efficiency impact.
+        # https://stackoverflow.com/questions/29877508/what-does-dtype-object-mean-while-creating-a-numpy-array
+        self.fitparams_amp = np.array(fitparams_amp,dtype=object)
+        self.fitparams_phase = np.array(fitparams_phase,dtype=object)
 
         print("spline knots = %i, num_fits = %i"%(n_spline_knots,num_fits))
 

--- a/test/test_regression.py
+++ b/test/test_regression.py
@@ -142,8 +142,8 @@ np.savez('data_notebook_basics_lesson4.npz',times=times,b_5=b_5,e_5=e_5,h_5=h_5,
   e_6 = EOBNRv2_sur.basis(5,'orthogonal')
   orthogonal_test = np.sum(e_5*np.conj(e_6)) * dt
   normalized_test = np.sum(e_5*np.conj(e_5)) * dt
-  assert( np.abs(orthogonal_test) < 1e-14 )
-  assert( np.abs(normalized_test-1.0) < 1e-14)
+  np.testing.assert_allclose(orthogonal_test, 0, rtol=0, atol=1.e-14)
+  np.testing.assert_allclose(normalized_test, 1.0, rtol=0, atol=1.e-14)
 
 #def test_notebook_basics_lesson5():
 #

--- a/test/test_regression.py
+++ b/test/test_regression.py
@@ -4,7 +4,6 @@ Regression data is stored in npz files.
 """
 
 from __future__ import division
-import nose
 import numpy as np
 import gwsurrogate as gws
 import os, sys
@@ -141,8 +140,10 @@ np.savez('data_notebook_basics_lesson4.npz',times=times,b_5=b_5,e_5=e_5,h_5=h_5,
   # basis orthogonality
   dt  = 1.0/2048.0 # found from surrogate *.dat file
   e_6 = EOBNRv2_sur.basis(5,'orthogonal')
-  nose.tools.assert_almost_equal(np.sum(e_5*np.conj(e_6)) * dt,0.0,places=14)
-  nose.tools.assert_almost_equal(np.sum(e_5*np.conj(e_5)) * dt,1.0,places=14)
+  orthogonal_test = np.sum(e_5*np.conj(e_6)) * dt
+  normalized_test = np.sum(e_5*np.conj(e_5)) * dt
+  assert( np.abs(orthogonal_test) < 1e-14 )
+  assert( np.abs(normalized_test-1.0) < 1e-14)
 
 #def test_notebook_basics_lesson5():
 #

--- a/test/test_unit.py
+++ b/test/test_unit.py
@@ -3,7 +3,6 @@ Simple unit tests.
 """
 
 from __future__ import division
-import nose
 import numpy as np
 import gwsurrogate as gws
 import os


### PR DESCRIPTION
- remove dependency on nose (which is now broken)
- numpy deprecated warning is now an error for converting ragged nested sequences

This PR fixes both of these issues. In particular:

https://github.com/sxs-collaboration/gwsurrogate/issues/46