### PR TITLE
Touch up arXiv references

### DIFF
--- a/tutorial/paper/paper.bib
+++ b/tutorial/paper/paper.bib
@@ -5,6 +5,8 @@
     eprint = "2311.01300",
     archivePrefix = "arXiv",
     primaryClass = "gr-qc",
+    journal = {arXiv e-prints},
+    doi = "10.48550/arXiv.2311.01300",
     month = "11",
     year = "2023"
 }
@@ -115,7 +117,7 @@
     archivePrefix = "arXiv",
     primaryClass = "gr-qc",
     doi = "10.1103/PhysRevResearch.1.033015",
-    journal = "Phys. Rev. Research.",
+    journal = "Phys. Rev. Research",
     volume = "1",
     pages = "033015",
     year = "2019"
@@ -220,6 +222,8 @@
   eprint = "2303.18203",
   archivePrefix = "arXiv",
   primaryClass = "gr-qc",
+  journal = {arXiv e-prints},
+  doi = "10.48550/arXiv.2303.18203",
   month = "3",
   year = "2023"
 }
@@ -319,6 +323,8 @@ howpublished = "\href{https://git.ligo.org/lscsoft/pyring}{git.ligo.org/lscsoft/
     archivePrefix = "arXiv",
     primaryClass = "gr-qc",
     reportNumber = "LIGO-P2100227",
+    journal = {arXiv e-prints},
+    doi = "10.48550/arXiv.2107.05609",
     month = "7",
     year = "2021"
 }


### PR DESCRIPTION
This is a small PR to add DOI and "journal" information to arXiv-only publications. This is part of the nearly completed [JOSS review](https://github.com/openjournals/joss-reviews/issues/7073) for this repo.