### PR TITLE
Speedup: use ndarray.min()/.max() instead of the python builtin

### DIFF
--- a/gwsurrogate/spline_interp_Cwrapper/spline_interp_Cwrapper.py
+++ b/gwsurrogate/spline_interp_Cwrapper/spline_interp_Cwrapper.py
@@ -38,7 +38,7 @@ else:
 
 def interpolate(xnew, x, y):
 
-    if min(xnew) < min(x) or max(xnew) > max(x):
+    if xnew.min() < x.min() or xnew.max() > x.max():
         raise Exception('Extrapolation not allowed')
 
     x = x.astype('float64')


### PR DESCRIPTION
This is to detect extrapolation in spline_interp_Cwrapper