### PR TITLE
Switch to GPR_fast as default.

### DIFF
--- a/gwsurrogate/new/nodeFunction.py
+++ b/gwsurrogate/new/nodeFunction.py
@@ -91,6 +91,21 @@ class pySurrogateFit(SimpleH5Object):
         self.h5_prepare_subs()
 
     def h5_prepare_subs(self):
+        if self.fit_data is not None and "fitType" in self.fit_data and self.fit_data["fitType"] == "GPR":
+            # eval_pysur now has an in-line implementation of GPR denoted
+            # by fitType "GPR_fast", which bypasses all of the internal
+            # scikit-learn checks. This is significantly faster, and so
+            # we default to using it. However, for future surrogates that
+            # 
+            # 1) want to return the variance of parametric fits, or
+            #
+            # 2) do not use ConstantKernel * RBF + WhiteKernel, and
+            #    do not subtract a linear fit before fitting the GPR
+            #
+            # this setting should be adjusted. In the future, there
+            # will be a helper function to change fitType after
+            # loading a surrogate.
+            self.fit_data["fitType"] = "GPR_fast"
         self.fitFunc = evaluate_fit.getFitEvaluator(self.fit_data)
 
     def __call__(self, x):

--- a/test/test_model_regression.py
+++ b/test/test_model_regression.py
@@ -86,7 +86,7 @@ rtol_default           = 1.e-11
 rtols = {'NRHybSur3dq8':  3.4e-5,
          'NRHybSur2dq15': 2.e-5,
          'NRHybSur3dq8_CCE': 7.e-5,  # higher modes for this GPR-fit model require a bit higher tolerance
-         'NRHybSur3dq8Tidal': 3.e-4,
+         'NRHybSur3dq8Tidal': 5.e-4,
          'SpEC_q1_10_NoSpin_linear_alt': 3.e-8, # needed for (8,7) mode to pass. Other modes pass with 1e-11 tolerance
          }
 


### PR DESCRIPTION
This switches to using the new in-line GPR evaluation routine introduced to `eval_pysur` in https://github.com/sxs-collaboration/eval_pysur/pull/2. For `NRSurE_q4NoSpin_22`, this is significantly faster. To avoid editing h5 files, we just change `GPR` to `GPR_fast` at load time.  In the future I will add a helper function that will allow for `fitType` to be adjusted after loading a surrogate.

Regression tests pass locally after slightly bumping the tolerance for `NRHybSur3dq8Tidal`, as otherwise I get the following:

```
============================================================ FAILURES ============================================================
_____________________________________________________ test_model_regression ______________________________________________________
test/test_model_regression.py:520: in test_model_regression
    np.testing.assert_allclose(h_regression, h_comparison, rtol=local_rtol, atol=atol, err_msg=err_msg)
/u/pjn/conda-envs/gwsur_fork/lib/python3.11/contextlib.py:81: in inner
    return func(*args, **kwds)
           ^^^^^^^^^^^^^^^^^^^
E   AssertionError: 
E   Not equal to tolerance rtol=0.0003, atol=0
E   Failed: model NRHybSur3dq8Tidal for mode index 4 (ell = 3,m = 0)
E   Mismatched elements: 1 / 71523 (0.0014%)
E   Max absolute difference among violations: 1.3270861e-32
E   Max relative difference among violations: 0.00039238
E    ACTUAL: array([0.000000e+00+0.000000e+00j, 0.000000e+00+0.000000e+00j,
E          0.000000e+00+0.000000e+00j, ..., 1.030805e-21+1.683432e-05j,
E          1.037828e-21+1.694902e-05j, 1.048176e-21+1.711801e-05j],
E         dtype=complex64)
E    DESIRED: array([0.000000e+00+0.000000e+00j, 0.000000e+00+0.000000e+00j,
E          0.000000e+00+0.000000e+00j, ..., 1.030805e-21+1.683432e-05j,
E          1.037828e-21+1.694902e-05j, 1.048176e-21+1.711801e-05j],
E         dtype=complex64)
```
