### PR TITLE
Python changes to reduce memory allocations & copies

### DIFF
--- a/gwsurrogate/new/precessing_surrogate.py
+++ b/gwsurrogate/new/precessing_surrogate.py
@@ -674,13 +674,16 @@ def _extract_component_data(h5_group):
     return data
 
 def _assemble_mode_pair(rep, rem, imp, imm):
-    hplus = rep + 1.j*imp
-    hminus = rem + 1.j*imm
-    # hplus and hminus were built with the (ell, -m) mode as the
-    # reference mode:
-    #   hplus = 0.5*( h^{ell, -m} + h^{ell, m}* )
-    #   hminus = 0.5*(h^{ell, -m} - h^{ell, m}* )
-    return (hplus - hminus).conjugate(), hplus + hminus
+    # hplus = rep + 1j*imp, hminus = rem + 1j*imm
+    # return (hplus - hminus).conj(), hplus + hminus
+    # Pre-allocate two outputs directly to avoid 3 intermediate allocations.
+    h_posm = np.empty(len(rep), dtype=np.complex128)
+    h_negm = np.empty(len(rep), dtype=np.complex128)
+    h_posm.real = rep - rem    # Re(hplus - hminus)
+    h_posm.imag = imm - imp    # Im((hplus - hminus).conj()) = -Im(hplus - hminus)
+    h_negm.real = rep + rem    # Re(hplus + hminus)
+    h_negm.imag = imp + imm    # Im(hplus + hminus)
+    return h_posm, h_negm
 
 #########################################################
 

--- a/gwsurrogate/new/precessing_surrogate.py
+++ b/gwsurrogate/new/precessing_surrogate.py
@@ -122,58 +122,50 @@ coprecessing frame to the inertial frame.
 
 ###############################################################################
 # Functions related to fit evaluations
-def _eval_scalar_fit(fit_data, fit_params, get_fit_settings):
+def _eval_scalar_fit(fit_data, fit_params, fit_settings):
     """ Evaluates a single scalar fit.
 
         Arguments:
         ==========
         fit_data: fit data for each specific datapiece
-        fit_params: function that takes a numpy array x and returns
-                    the fit parameters used to evaluate the surrogate fits.
-                    Example: The NRSur7dq4 model converts
-                       x=[q, chi1x, chi1y, chi1z, chi2x, chi2y, chi2z]
-                       to
-                       x=[np.log(q), chi1x, chi1y, chiHat, chi2x, chi2y, chi_a]
-        get_fit_settings: function that provides information about
-                          surrogate fits for each specific datapiece.
+        fit_params: numpy array of fit parameters (already transformed)
+        fit_settings: tuple (q_fit_offset, q_fit_slope, q_max_bfOrder,
+                      chi_max_bfOrder) — model-specific constants, cached
+                      once at init time.
 
         Notes:
         ======
-        fit_params and get_fit_settings should come from each surrogate model's
+        fit_params and fit_settings should come from each surrogate model's
         class definition. For example, for the NRSur7dq4 model, these are defined
         in NRSur7dq4(SurrogateEvaluator)
     """
     q_fit_offset, q_fit_slope, q_max_bfOrder, chi_max_bfOrder \
-        = get_fit_settings()
+        = fit_settings
     val = _utils.eval_fit(fit_data['bfOrders'], fit_data['coefs'], \
         fit_params, q_fit_offset, q_fit_slope, q_max_bfOrder, chi_max_bfOrder)
     return val
 
-def _eval_vector_fit(fit_data, size, fit_params, get_fit_settings):
+def _eval_vector_fit(fit_data, size, fit_params, fit_settings):
     """ Evaluates a vector fit, where each element is a scalar fit.
 
         Arguments:
         ==========
         fit_data: fit data for each specific datapiece
-        fit_params: function that takes a numpy array x and returns
-                    the fit parameters used to evaluate the surrogate fits.
-                    Example: The NRSur7dq4 model converts
-                       x=[q, chi1x, chi1y, chi1z, chi2x, chi2y, chi2z]
-                       to
-                       x=[np.log(q), chi1x, chi1y, chiHat, chi2x, chi2y, chi_a]
-        get_fit_settings: function that provides information about
-                          surrogate fits for each specific datapiece.
+        fit_params: numpy array of fit parameters (already transformed)
+        fit_settings: tuple (q_fit_offset, q_fit_slope, q_max_bfOrder,
+                      chi_max_bfOrder) — model-specific constants, cached
+                      once at init time.
 
         Notes:
         ======
-        fit_params and get_fit_settings should come from each surrogate model's
+        fit_params and fit_settings should come from each surrogate model's
         class definition. For example, for the NRSur7dq4 model, these are defined
         in NRSur7dq4(SurrogateEvaluator)
     """
-    val = []
+    val = np.empty(size)
     for i in range(size):
-        val.append(_eval_scalar_fit(fit_data[i], fit_params, get_fit_settings))
-    return np.asarray(val)
+        val[i] = _eval_scalar_fit(fit_data[i], fit_params, fit_settings)
+    return val
 
 ###############################################################################
 
@@ -220,6 +212,7 @@ These time derivatives are given to the AB4 ODE solver.
 
         self._get_fit_params = get_fit_params
         self._get_fit_settings = get_fit_settings
+        self._fit_settings = get_fit_settings()
         self.omega_ref_max_model = omega_ref_max_model
 
         self.fit_data = []
@@ -270,10 +263,10 @@ These time derivatives are given to the AB4 ODE solver.
 
         # Evaluate fits
         data = self.fit_data[i0]
-        ooxy_coorb = _eval_vector_fit(data['omega_orb'], 2, fit_params, self._get_fit_settings)
-        omega = _eval_scalar_fit(data['omega'], fit_params, self._get_fit_settings)
-        cAdot_coorb = _eval_vector_fit(data['chiA'], 3, fit_params, self._get_fit_settings)
-        cBdot_coorb = _eval_vector_fit(data['chiB'], 3, fit_params, self._get_fit_settings)
+        ooxy_coorb = _eval_vector_fit(data['omega_orb'], 2, fit_params, self._fit_settings)
+        omega = _eval_scalar_fit(data['omega'], fit_params, self._fit_settings)
+        cAdot_coorb = _eval_vector_fit(data['chiA'], 3, fit_params, self._fit_settings)
+        cBdot_coorb = _eval_vector_fit(data['chiB'], 3, fit_params, self._fit_settings)
 
         # Do rotations to the coprecessing frame, find dqdt, and append
         dydt = _utils.assemble_dydt(y, ooxy_coorb, omega,
@@ -307,7 +300,7 @@ cubic interpolation. Use get_time_deriv_from_index when possible.
     def get_omega(self, i0, q, y):
         x = _utils.get_ds_fit_x(y, q)
         fit_params = self._get_fit_params(x)
-        omega = _eval_scalar_fit(self.fit_data[i0]['omega'], fit_params, self._get_fit_settings)
+        omega = _eval_scalar_fit(self.fit_data[i0]['omega'], fit_params, self._fit_settings)
         return omega
 
     def _get_t_from_omega(self, omega_ref, q, chiA0, chiB0, init_orbphase,
@@ -702,6 +695,7 @@ class CoorbitalWaveformSurrogate:
 
         self._get_fit_params = get_fit_params
         self._get_fit_settings = get_fit_settings
+        self._fit_settings = get_fit_settings()
 
         self.ellMax = 2
         while 'hCoorb_%s_%s_Re+'%(self.ellMax+1, self.ellMax+1) in h5file.keys():
@@ -785,7 +779,7 @@ ellMax: The maximum ell mode to evaluate.
                 }
             x = np.append(q, np.append(chiA[ni], chiB[ni]))
             fit_params = self._get_fit_params(x)
-            nodes.append(_eval_scalar_fit(fit_data, fit_params, self._get_fit_settings))
+            nodes.append(_eval_scalar_fit(fit_data, fit_params, self._fit_settings))
 
         return np.array(nodes).dot(data['EI_basis'])
 

--- a/gwsurrogate/new/precessing_surrogate.py
+++ b/gwsurrogate/new/precessing_surrogate.py
@@ -216,6 +216,7 @@ These time derivatives are given to the AB4 ODE solver.
         self.omega_ref_max_model = omega_ref_max_model
 
         self.fit_data = []
+        self.fit_data_batch = []
         for i in range(len(self.t)):
             group = h5file['ds_node_%s'%(i)]
             tmp_data = {}
@@ -227,6 +228,19 @@ These time derivatives are given to the AB4 ODE solver.
             tmp_data['chiB'] =self._load_vector_fit(group, 'chiB', 3)
 
             self.fit_data.append(tmp_data)
+
+            # Build the batch list: [ooxy0, ooxy1, omega, cAx, cAy, cAz, cBx, cBy, cBz]
+            self.fit_data_batch.append([
+                (tmp_data['omega_orb'][0]['bfOrders'], tmp_data['omega_orb'][0]['coefs']),
+                (tmp_data['omega_orb'][1]['bfOrders'], tmp_data['omega_orb'][1]['coefs']),
+                (tmp_data['omega']['bfOrders'],         tmp_data['omega']['coefs']),
+                (tmp_data['chiA'][0]['bfOrders'],        tmp_data['chiA'][0]['coefs']),
+                (tmp_data['chiA'][1]['bfOrders'],        tmp_data['chiA'][1]['coefs']),
+                (tmp_data['chiA'][2]['bfOrders'],        tmp_data['chiA'][2]['coefs']),
+                (tmp_data['chiB'][0]['bfOrders'],        tmp_data['chiB'][0]['coefs']),
+                (tmp_data['chiB'][1]['bfOrders'],        tmp_data['chiB'][1]['coefs']),
+                (tmp_data['chiB'][2]['bfOrders'],        tmp_data['chiB'][2]['coefs']),
+            ])
 
         self.diff_t = np.diff(self.t)
         self.L = len(self.t)
@@ -261,16 +275,11 @@ These time derivatives are given to the AB4 ODE solver.
         x = _utils.get_ds_fit_x(y, q)
         fit_params = self._get_fit_params(x)
 
-        # Evaluate fits
-        data = self.fit_data[i0]
-        ooxy_coorb = _eval_vector_fit(data['omega_orb'], 2, fit_params, self._fit_settings)
-        omega = _eval_scalar_fit(data['omega'], fit_params, self._fit_settings)
-        cAdot_coorb = _eval_vector_fit(data['chiA'], 3, fit_params, self._fit_settings)
-        cBdot_coorb = _eval_vector_fit(data['chiB'], 3, fit_params, self._fit_settings)
-
-        # Do rotations to the coprecessing frame, find dqdt, and append
-        dydt = _utils.assemble_dydt(y, ooxy_coorb, omega,
-                cAdot_coorb, cBdot_coorb)
+        # Fused: evaluate 9 fits + assemble dydt in one C call
+        q_fit_offset, q_fit_slope, q_max_bfOrder, chi_max_bfOrder = self._fit_settings
+        dydt = _utils.eval_fit_batch_dydt(
+            self.fit_data_batch[i0], fit_params, y,
+            q_fit_offset, q_fit_slope, q_max_bfOrder, chi_max_bfOrder)
 
         return dydt
 

--- a/gwsurrogate/new/precessing_surrogate.py
+++ b/gwsurrogate/new/precessing_surrogate.py
@@ -145,28 +145,6 @@ def _eval_scalar_fit(fit_data, fit_params, fit_settings):
         fit_params, q_fit_offset, q_fit_slope, q_max_bfOrder, chi_max_bfOrder)
     return val
 
-def _eval_vector_fit(fit_data, size, fit_params, fit_settings):
-    """ Evaluates a vector fit, where each element is a scalar fit.
-
-        Arguments:
-        ==========
-        fit_data: fit data for each specific datapiece
-        fit_params: numpy array of fit parameters (already transformed)
-        fit_settings: tuple (q_fit_offset, q_fit_slope, q_max_bfOrder,
-                      chi_max_bfOrder) — model-specific constants, cached
-                      once at init time.
-
-        Notes:
-        ======
-        fit_params and fit_settings should come from each surrogate model's
-        class definition. For example, for the NRSur7dq4 model, these are defined
-        in NRSur7dq4(SurrogateEvaluator)
-    """
-    val = np.empty(size)
-    for i in range(size):
-        val[i] = _eval_scalar_fit(fit_data[i], fit_params, fit_settings)
-    return val
-
 ###############################################################################
 
 class DynamicsSurrogate:

--- a/gwsurrogate/new/precessing_surrogate.py
+++ b/gwsurrogate/new/precessing_surrogate.py
@@ -743,7 +743,7 @@ chiA, chiB: The time-dependent spin in the coorbital frame. These should have
 ellMax: The maximum ell mode to evaluate.
         """
         nmodes = ellMax*ellMax + 2*ellMax - 3
-        modes = 1.j*np.zeros((nmodes, len(self.t)))
+        modes = np.zeros((nmodes, len(self.t)), dtype=complex)
 
         for ell in range(2, ellMax+1):
 

--- a/gwsurrogate/new/precessing_surrogate.py
+++ b/gwsurrogate/new/precessing_surrogate.py
@@ -503,7 +503,7 @@ the nearest time node.
         #   chiBy, chiBz]
         # We do three steps of RK4, so we have 3 fewer timesteps in the output
         # compared to self.t
-        data = np.zeros((self.L-3, 11))
+        data = np.empty((self.L-3, 11))  # every row written by RK4/AB4 before use
 
         y0 = np.append(np.array([1., 0., 0., 0., init_orbphase]),
                 np.append(chiA0, chiB0))

--- a/gwsurrogate/new/precessing_surrogate.py
+++ b/gwsurrogate/new/precessing_surrogate.py
@@ -1039,7 +1039,7 @@ Returns:
         orbphase = _splinterp_Cwrapper(self.t_coorb, self.tds, orbphase_dyn)
 
         quat = splinterp_many(self.t_coorb, self.tds, quat_dyn)
-        quat = quat/np.sqrt(np.sum(abs(quat)**2, 0))
+        quat = quat/np.sqrt((quat*quat).sum(0))
         chiA_coorb, chiB_coorb = coorb_spins_from_copr_spins(
                 chiA_copr, chiB_copr, orbphase)
 
@@ -1105,7 +1105,9 @@ Returns:
                 chiB_copr = normalize_spin(chiB_copr, chiB_norm)
                 orbphase = _splinterp_Cwrapper(timesM, self.tds, orbphase_dyn)
                 quat = splinterp_many(timesM, self.tds, quat_dyn)
-                quat = quat/np.sqrt(np.sum(abs(quat)**2, 0))
+                # Note that quat is a 4-number array so we don't have to do
+                # conjugation of the quaternion, etc.
+                quat = quat/np.sqrt((quat*quat).sum(0))
 
             chiA_inertial = transformTimeDependentVector(quat, chiA_copr.T).T
             chiB_inertial = transformTimeDependentVector(quat, chiB_copr.T).T

--- a/gwsurrogate/new/precessing_surrogate.py
+++ b/gwsurrogate/new/precessing_surrogate.py
@@ -145,6 +145,28 @@ def _eval_scalar_fit(fit_data, fit_params, fit_settings):
         fit_params, q_fit_offset, q_fit_slope, q_max_bfOrder, chi_max_bfOrder)
     return val
 
+def _eval_vector_fit(fit_data, size, fit_params, fit_settings):
+    """ Evaluates a vector fit, where each element is a scalar fit.
+
+        Arguments:
+        ==========
+        fit_data: fit data for each specific datapiece
+        fit_params: numpy array of fit parameters (already transformed)
+        fit_settings: tuple (q_fit_offset, q_fit_slope, q_max_bfOrder,
+                      chi_max_bfOrder) — model-specific constants, cached
+                      once at init time.
+
+        Notes:
+        ======
+        fit_params and fit_settings should come from each surrogate model's
+        class definition. For example, for the NRSur7dq4 model, these are defined
+        in NRSur7dq4(SurrogateEvaluator)
+    """
+    val = np.empty(size)
+    for i in range(size):
+        val[i] = _eval_scalar_fit(fit_data[i], fit_params, fit_settings)
+    return val
+
 ###############################################################################
 
 class DynamicsSurrogate:
@@ -252,6 +274,17 @@ These time derivatives are given to the AB4 ODE solver.
         # Setup fit variables
         x = _utils.get_ds_fit_x(y, q)
         fit_params = self._get_fit_params(x)
+
+        # Reference implementation for the fused C path below:
+        #
+        # data = self.fit_data[i0]
+        # ooxy_coorb = _eval_vector_fit(data['omega_orb'], 2, fit_params, self._fit_settings)
+        # omega = _eval_scalar_fit(data['omega'], fit_params, self._fit_settings)
+        # cAdot_coorb = _eval_vector_fit(data['chiA'], 3, fit_params, self._fit_settings)
+        # cBdot_coorb = _eval_vector_fit(data['chiB'], 3, fit_params, self._fit_settings)
+        # dydt = _utils.assemble_dydt(
+        #     y, ooxy_coorb, omega, cAdot_coorb, cBdot_coorb
+        # )
 
         # Fused: evaluate 9 fits + assemble dydt in one C call
         q_fit_offset, q_fit_slope, q_max_bfOrder, chi_max_bfOrder = self._fit_settings

--- a/gwsurrogate/new/precessing_surrogate.py
+++ b/gwsurrogate/new/precessing_surrogate.py
@@ -62,9 +62,11 @@ http://arxiv.org/abs/1302.2919
     n = q.shape[1]
     num_ells = ellMax - 1
 
-    # Allocate output — Python owns the memory
+    # Allocate output — Python owns the memory.
+    # C zeros them only when edge-case time points exist (n2>0 or n3>0);
+    # in the general case every element is written, so np.empty suffices.
     matrices = [
-        np.zeros((2*(i+2)+1, 2*(i+2)+1, n), dtype=np.complex128)
+        np.empty((2*(i+2)+1, 2*(i+2)+1, n), dtype=np.complex128)
         for i in range(num_ells)
     ]
 

--- a/gwsurrogate/precessing_utils/include/precessing_utils.h
+++ b/gwsurrogate/precessing_utils/include/precessing_utils.h
@@ -1,5 +1,7 @@
 double ipow(double base, long exponent);
 static PyObject *eval_fit(PyObject *self, PyObject *args);
+static PyObject *eval_fit_batch(PyObject *self, PyObject *args);
+static PyObject *eval_fit_batch_dydt(PyObject *self, PyObject *args);
 static PyObject *normalize_y(PyObject *self, PyObject *args);
 static PyObject *get_ds_fit_x(PyObject *self, PyObject *args);
 static PyObject *assemble_dydt(PyObject *self, PyObject *args);

--- a/gwsurrogate/precessing_utils/src/precessing_utils.c
+++ b/gwsurrogate/precessing_utils/src/precessing_utils.c
@@ -488,8 +488,11 @@ static PyObject *eval_fit_batch_dydt(PyObject *self, PyObject *args) {
     eval_fits_into(fit_list, 9, x_powers,
                    q_max_bfOrder, chi_max_bfOrder, results);
 
-    /* Assemble dydt from results: ooxy=results[0:2], omega=results[2],
-       cAdot=results[3:6], cBdot=results[6:9] */
+    /* Assemble dydt from batched fit results:
+       results[0:2] = ooxy_coorb components,
+       results[2]   = orbital phase derivative omega,
+       results[3:6] = chiA time derivative in the coorbital frame,
+       results[6:9] = chiB time derivative in the coorbital frame. */
     npy_intp dims[1] = {11};
     PyArrayObject *dydt = (PyArrayObject *) PyArray_SimpleNew(1, dims, NPY_DOUBLE);
     if (!dydt) return NULL;
@@ -498,7 +501,7 @@ static PyObject *eval_fit_batch_dydt(PyObject *self, PyObject *args) {
     double cp = cos(y_data[4]);
     double sp = sin(y_data[4]);
 
-    /* Rotate ooxy from coorbital to coprecessing frame */
+    /* Rotate ooxy_coorb from the coorbital frame to the coprecessing frame. */
     double ooxy_x = results[0]*cp - results[1]*sp;
     double ooxy_y = results[0]*sp + results[1]*cp;
 
@@ -551,7 +554,7 @@ static PyObject *assemble_dydt(PyObject *self, PyObject *args) {
     // Parse tuples
     if (!PyArg_ParseTuple(args, "O!O!dO!O!",
             &PyArray_Type, &y,      // length 11, has quat, orbphase, chiA_copr, chiB_copr
-            &PyArray_Type, &ooxy,   // length 2 with x and y components of \Omega^{copr}
+            &PyArray_Type, &ooxy,   // length 2 with x and y components of \Omega^{coorb}
             &omega,                 // double, orbital frequency \omega
             &PyArray_Type, &cAdot,  // length 3, coprecessing chiA time derivative
             &PyArray_Type, &cBdot)) return NULL;

--- a/gwsurrogate/precessing_utils/src/precessing_utils.c
+++ b/gwsurrogate/precessing_utils/src/precessing_utils.c
@@ -59,6 +59,8 @@ static struct module_state _state;
 /* ==== Setup the python methods table === */
 static PyMethodDef _utils_methods[] = {
     {"eval_fit", eval_fit, METH_VARARGS},
+    {"eval_fit_batch", eval_fit_batch, METH_VARARGS},
+    {"eval_fit_batch_dydt", eval_fit_batch_dydt, METH_VARARGS},
     {"normalize_y", normalize_y, METH_VARARGS},
     {"get_ds_fit_x", get_ds_fit_x, METH_VARARGS},
     {"assemble_dydt", assemble_dydt, METH_VARARGS},
@@ -147,6 +149,80 @@ double ipow(double base, long exponent) {
 }
 
 /*
+ * Fill the x_powers lookup table shared by all fit evaluations. The table layout is:
+ *   indices [0 .. q_max_bfOrder]                 -> powers of the rescaled q parameter
+ *   indices [base_j .. base_j + chi_max_bfOrder] -> powers of x_data[j], for j=1..6,
+ *     where base_j = q_max_bfOrder+1 + (chi_max_bfOrder+1)*(j-1).
+ * Powers are built incrementally (one multiply per entry) rather than with ipow, and the
+ * chi loop runs j outer / power inner so each parameter's powers are written sequentially.
+ */
+static void compute_x_powers(const double *x_data,
+                             double q_fit_offset, double q_fit_slope,
+                             int q_max_bfOrder, int chi_max_bfOrder,
+                             double *x_powers) {
+    int i, j;
+
+    // q powers
+    double qbase = q_fit_offset + q_fit_slope*x_data[0];
+    x_powers[0] = 1.0;
+    for (i=1; i <= q_max_bfOrder; i++) {
+        x_powers[i] = x_powers[i-1]*qbase;
+    }
+
+    // chi powers
+    for (j=1; j<7; j++) {
+        int base_idx = q_max_bfOrder+1 + (chi_max_bfOrder+1)*(j-1);
+        double cbase = x_data[j];
+        x_powers[base_idx] = 1.0;
+        for (i=1; i <= chi_max_bfOrder; i++) {
+            x_powers[base_idx + i] = x_powers[base_idx + i - 1]*cbase;
+        }
+    }
+}
+
+/*
+ * Evaluate a single parametric fit given a precomputed x_powers table.
+ * Sums coef[i] times the product of 7 basis functions (one power per parameter).
+ */
+static double eval_one_fit(const long *bf_order_data, const double *coef_data, int n,
+                           const double *x_powers,
+                           int q_max_bfOrder, int chi_max_bfOrder) {
+    int i, j;
+    double res = 0.0;
+    for (i=0; i<n; i++) {
+        const long *orders = bf_order_data + i*7;
+        double prod = x_powers[orders[0]];
+        for (j=1; j<7; j++) {
+            int base_idx = q_max_bfOrder+1 + (chi_max_bfOrder+1)*(j-1);
+            prod *= x_powers[base_idx + orders[j]];
+        }
+        res += coef_data[i]*prod;
+    }
+    return res;
+}
+
+/*
+ * Evaluate a batch of fits (a Python list of (bfOrders, coefs) tuples) sharing a single
+ * x_powers table, writing the n_fits results into the caller-provided out buffer.
+ */
+static void eval_fits_into(PyObject *fit_list, int n_fits, const double *x_powers,
+                           int q_max_bfOrder, int chi_max_bfOrder, double *out) {
+    int k;
+    for (k=0; k<n_fits; k++) {
+        PyObject *fit_tuple = PyList_GET_ITEM(fit_list, k);
+        PyArrayObject *bf_orders = (PyArrayObject *) PyTuple_GET_ITEM(fit_tuple, 0);
+        PyArrayObject *coefs_arr = (PyArrayObject *) PyTuple_GET_ITEM(fit_tuple, 1);
+
+        long   *bf_order_data = (long *)   PyArray_DATA(bf_orders);
+        double *coef_data     = (double *) PyArray_DATA(coefs_arr);
+        int n = (int) PyArray_DIMS(coefs_arr)[0];
+
+        out[k] = eval_one_fit(bf_order_data, coef_data, n, x_powers,
+                              q_max_bfOrder, chi_max_bfOrder);
+    }
+}
+
+/*
  * This function evaluates a parametric fit.
  * Arguments (with python data types):
  *      bf_orders:  A 2d integer numpy array with shape (n_coefs, 7).
@@ -170,9 +246,9 @@ double ipow(double base, long exponent) {
 static PyObject *eval_fit(PyObject *self, PyObject *args) {
 
     PyArrayObject *bf_orders, *coefs, *x;
-    int i, j, n;
-    long *bf_order_data, *orders;
-    double res, prod, *coef_data, *x_data, q_fit_offset, q_fit_slope;
+    int n;
+    long *bf_order_data;
+    double res, *coef_data, *x_data, q_fit_offset, q_fit_slope;
     int q_max_bfOrder, chi_max_bfOrder;
 
     // Parse tuples
@@ -194,32 +270,68 @@ static PyObject *eval_fit(PyObject *self, PyObject *args) {
     coef_data = (double *) PyArray_DATA(coefs);
     x_data = (double *) PyArray_DATA(x);
     n = PyArray_DIMS(coefs)[0];
-    res = 0.0;
 
-    // Compute all needed powers
-    for (i=0; i <= q_max_bfOrder; i++){        // power of q parameter
-        x_powers[i] = ipow(q_fit_offset + q_fit_slope*x_data[0], i);
-    }
-    int base_idx;
-    for (i=0; i <= chi_max_bfOrder; i++){      // power of chi parameters
-        for (j=1; j<7; j++){
-            base_idx = q_max_bfOrder+1 + (chi_max_bfOrder+1)*(j-1);
-            x_powers[base_idx + i] = ipow(x_data[j], i);
-        }
-    }
-
-    // Sum up result
-    for (i=0; i<n; i++) {
-        orders = bf_order_data + i*7;   // shift address of pointer
-        prod = x_powers[orders[0]];
-        for (j=1; j<7; j++) {
-            base_idx = q_max_bfOrder+1 + (chi_max_bfOrder+1)*(j-1);
-            prod *= x_powers[base_idx+ orders[j]];
-        }
-        res += coef_data[i]*prod;
-    }
+    // Compute all needed powers, then sum up the result
+    compute_x_powers(x_data, q_fit_offset, q_fit_slope,
+                     q_max_bfOrder, chi_max_bfOrder, x_powers);
+    res = eval_one_fit(bf_order_data, coef_data, n, x_powers,
+                       q_max_bfOrder, chi_max_bfOrder);
 
     return Py_BuildValue("d", res);
+}
+
+
+/*
+ * Evaluates a batch of scalar fits sharing the same x (fit_params) vector.
+ * This avoids recomputing x_powers for each fit, reducing overhead by ~9x
+ * compared to calling eval_fit 9 times per ODE step.
+ *
+ * Arguments (with python data types):
+ *      fit_list:  A Python list of (bfOrders, coefs) tuples, one per fit.
+ *                 bfOrders: 2d int numpy array shape (n_coefs, 7)
+ *                 coefs: 1d float numpy array length n_coefs
+ *      x:             A 1d float numpy array with length 7 (fit parameters).
+ *      q_fit_offset:  A double.
+ *      q_fit_slope:   A double.
+ *      q_max_bfOrder: An int.
+ *      chi_max_bfOrder: An int.
+ *
+ * Returns a 1d float numpy array of length len(fit_list) with results.
+ */
+static PyObject *eval_fit_batch(PyObject *self, PyObject *args) {
+
+    PyObject *fit_list;
+    PyArrayObject *x;
+    double q_fit_offset, q_fit_slope;
+    int q_max_bfOrder, chi_max_bfOrder;
+
+    if (!PyArg_ParseTuple(args, "OO!ddii",
+            &fit_list,
+            &PyArray_Type, &x,
+            &q_fit_offset,
+            &q_fit_slope,
+            &q_max_bfOrder,
+            &chi_max_bfOrder)) return NULL;
+
+    double *x_data = (double *) PyArray_DATA(x);
+    int n_fits = (int) PyList_GET_SIZE(fit_list);
+
+    /* Pre-compute x_powers once for all fits in the batch */
+    double x_powers[q_max_bfOrder+1 + 6*(chi_max_bfOrder+1)];
+    compute_x_powers(x_data, q_fit_offset, q_fit_slope,
+                     q_max_bfOrder, chi_max_bfOrder, x_powers);
+
+    /* Allocate output array */
+    npy_intp dims[1] = {n_fits};
+    PyArrayObject *result = (PyArrayObject *) PyArray_SimpleNew(1, dims, NPY_DOUBLE);
+    if (!result) return NULL;
+    double *result_data = (double *) PyArray_DATA(result);
+
+    /* Evaluate each fit using the shared x_powers */
+    eval_fits_into(fit_list, n_fits, x_powers,
+                   q_max_bfOrder, chi_max_bfOrder, result_data);
+
+    return PyArray_Return(result);
 }
 
 
@@ -333,6 +445,83 @@ static PyObject *get_ds_fit_x(PyObject *self, PyObject *args) {
 
     return PyArray_Return(x);
 }
+
+/*
+ * Fused eval_fit_batch + assemble_dydt: evaluates 9 polynomial fits and
+ * assembles the ODE right-hand-side in a single C call.
+ *
+ * Arguments:
+ *      fit_list:   Python list of 9 tuples (bf_orders, coefs)
+ *      fit_params: length-7 float numpy array (transformed fit parameters)
+ *      y:          length-11 float numpy array (quat, orbphase, chiA_copr, chiB_copr)
+ *      q_fit_offset, q_fit_slope: doubles for q rescaling
+ *      q_max_bfOrder, chi_max_bfOrder: ints for max basis function orders
+ *
+ * Returns a length-11 float numpy array dydt.
+ */
+static PyObject *eval_fit_batch_dydt(PyObject *self, PyObject *args) {
+
+    PyObject *fit_list;
+    PyArrayObject *fit_params, *y;
+    double q_fit_offset, q_fit_slope;
+    int q_max_bfOrder, chi_max_bfOrder;
+
+    if (!PyArg_ParseTuple(args, "OO!O!ddii",
+            &fit_list,
+            &PyArray_Type, &fit_params,
+            &PyArray_Type, &y,
+            &q_fit_offset,
+            &q_fit_slope,
+            &q_max_bfOrder,
+            &chi_max_bfOrder)) return NULL;
+
+    double *x_data = (double *) PyArray_DATA(fit_params);
+    double *y_data = (double *) PyArray_DATA(y);
+
+    /* Pre-compute x_powers once for all fits */
+    double x_powers[q_max_bfOrder+1 + 6*(chi_max_bfOrder+1)];
+    compute_x_powers(x_data, q_fit_offset, q_fit_slope,
+                     q_max_bfOrder, chi_max_bfOrder, x_powers);
+
+    /* Evaluate 9 fits into stack array */
+    double results[9];
+    eval_fits_into(fit_list, 9, x_powers,
+                   q_max_bfOrder, chi_max_bfOrder, results);
+
+    /* Assemble dydt from results: ooxy=results[0:2], omega=results[2],
+       cAdot=results[3:6], cBdot=results[6:9] */
+    npy_intp dims[1] = {11};
+    PyArrayObject *dydt = (PyArrayObject *) PyArray_SimpleNew(1, dims, NPY_DOUBLE);
+    if (!dydt) return NULL;
+    double *dydt_data = (double *) PyArray_DATA(dydt);
+
+    double cp = cos(y_data[4]);
+    double sp = sin(y_data[4]);
+
+    /* Rotate ooxy from coorbital to coprecessing frame */
+    double ooxy_x = results[0]*cp - results[1]*sp;
+    double ooxy_y = results[0]*sp + results[1]*cp;
+
+    /* Quaternion derivative */
+    dydt_data[0] = (-0.5)*y_data[1]*ooxy_x - 0.5*y_data[2]*ooxy_y;
+    dydt_data[1] = (-0.5)*y_data[3]*ooxy_y + 0.5*y_data[0]*ooxy_x;
+    dydt_data[2] = 0.5*y_data[3]*ooxy_x + 0.5*y_data[0]*ooxy_y;
+    dydt_data[3] = 0.5*y_data[1]*ooxy_y - 0.5*y_data[2]*ooxy_x;
+
+    /* Orbital phase derivative */
+    dydt_data[4] = results[2];
+
+    /* Spin derivatives: rotate from coorbital to coprecessing */
+    dydt_data[5] = results[3]*cp - results[4]*sp;
+    dydt_data[6] = results[3]*sp + results[4]*cp;
+    dydt_data[7] = results[5];
+    dydt_data[8] = results[6]*cp - results[7]*sp;
+    dydt_data[9] = results[6]*sp + results[7]*cp;
+    dydt_data[10] = results[8];
+
+    return PyArray_Return(dydt);
+}
+
 
 /*
  * This function assembles the right-hand-side of the dynamics ODE integration


### PR DESCRIPTION
These are a few more low-hanging fruits for speeding up the surrogate evaluation.